### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete multi-character sanitization

### DIFF
--- a/src/lib/services/email/providers/resend.ts
+++ b/src/lib/services/email/providers/resend.ts
@@ -45,12 +45,19 @@ export class ResendProvider implements EmailProvider {
     }
 
     private htmlToText(html: string): string {
-        return html
+        // Remove standard HTML formatting first
+        let str = html
             .replace(/<br\s*\/?>/gi, '\n')
             .replace(/<\/p>/gi, '\n\n')
             .replace(/<\/div>/gi, '\n')
-            .replace(/<\/h[1-6]>/gi, '\n\n')
-            .replace(/<[^>]*>/g, '')
+            .replace(/<\/h[1-6]>/gi, '\n\n');
+        // Safely remove all HTML tags (including problematic multi-character sequences)
+        let prev;
+        do {
+            prev = str;
+            str = str.replace(/<[^>]*>/g, '');
+        } while (str !== prev);
+        return str
             .replace(/&nbsp;/g, ' ')
             .replace(/&amp;/g, '&')
             .replace(/&lt;/g, '<')


### PR DESCRIPTION
Potential fix for [https://github.com/nitrokit/nitrokit-nextjs/security/code-scanning/3](https://github.com/nitrokit/nitrokit-nextjs/security/code-scanning/3)

To reliably sanitize HTML and convert to text, it is best to use a dedicated library such as `sanitize-html` to remove all tags and decode entities. However, if library use is not permitted, a safer fix is to repeatedly apply the tag-removal regular expression until no more tags remain, ensuring multi-character and nested tags are eliminated. In this case, update the `.replace(/<[^>]*>/g, '')` call so that it runs in a loop until the string stops changing, or use a library like `sanitize-html` for sanitization and then decode HTML entities.  
Changes are limited to the `htmlToText` private method, within `src/lib/services/email/providers/resend.ts`. If we use a library, add its import at the top. If not, refactor the method to repeat the replacement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
