### PR TITLE
Potential fix for code scanning alert no. 4: Double escaping or unescaping

### DIFF
--- a/src/lib/services/email/providers/resend.ts
+++ b/src/lib/services/email/providers/resend.ts
@@ -59,11 +59,11 @@ export class ResendProvider implements EmailProvider {
         } while (str !== prev);
         return str
             .replace(/&nbsp;/g, ' ')
-            .replace(/&amp;/g, '&')
             .replace(/&lt;/g, '<')
             .replace(/&gt;/g, '>')
             .replace(/&quot;/g, '"')
             .replace(/&#39;/g, "'")
+            .replace(/&amp;/g, '&')
             .trim()
             .replace(/\n\s*\n\s*\n/g, '\n\n');
     }


### PR DESCRIPTION
Potential fix for [https://github.com/nitrokit/nitrokit-nextjs/security/code-scanning/4](https://github.com/nitrokit/nitrokit-nextjs/security/code-scanning/4)

To fix the problem, we need to ensure that the HTML entity unescaping happens in the correct order: replace all other named entities (like `&lt;`, `&gt;`, etc.) **before** replacing `&amp;`. The simplest way is to reorder the `.replace` calls so that `&amp;` is replaced last. Only the relative order of `.replace(/&amp;/g, '&')` with respect to the other replacements on lines 61–66 needs to be changed. No external libraries are required, but a more robust long-term solution would use a library like `he`, though the prompt suggests only to use libraries if needed.  
Edits only need to occur within the `htmlToText` method in this file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
